### PR TITLE
Use fail-fast to limit errors

### DIFF
--- a/script/run
+++ b/script/run
@@ -1,1 +1,1 @@
-docker run --rm -it -v "$PWD":/app -w /app rspec_koans rspec
+docker run --rm -it -v "$PWD":/app -w /app rspec_koans rspec --fail-fast


### PR DESCRIPTION
We only want to show the _next_ test the person should work on. Using
Fail Fast, Rspec stops running when it hits a failing test. So we will
only display one error at a time.