### PR TITLE
Third suite

### DIFF
--- a/spec/koans/00_direct_testing_spec.rb
+++ b/spec/koans/00_direct_testing_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "When testing a class" do
   describe "when testing methods that do not exist" do
     describe Person do
       it "will fail" do
-        expect { subject.minnesota }.to raise_error(PlaceHolderError), "Update the PlaceHolderError with the type of error that is raised"
+        expect { subject.minnesota }.to raise_error(PlaceholderError), "Update the PlaceHolderError with the type of error that is raised"
       end
     end
   end

--- a/spec/koans/01_collaborator_class_spec.rb
+++ b/spec/koans/01_collaborator_class_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "When testing a collaborator" do
         it "and you can't use person methods that don't exist" do
           person = Person.new
 
-          expect{ person.minnesota }.to raise_error(PlaceHolderError)
+          expect{ person.minnesota }.to raise_error(PlaceholderError)
         end
       end
 

--- a/spec/koans/02_plain_ruby_collaborators_spec.rb
+++ b/spec/koans/02_plain_ruby_collaborators_spec.rb
@@ -1,0 +1,89 @@
+require_relative "../spec_helper"
+require 'person'
+require 'greeting'
+require 'date'
+require 'ostruct'
+
+RSpec.describe "When testing a collaborator" do
+  describe "you can use plain Ruby objects as a stand-in" do
+    describe Greeting, "using OpenStruct as a collaborator" do
+      describe "there are benefits to using a collaborator stand in" do
+        it "it is not hard" do
+          standin_person = OpenStruct.new(full_name: _placeholder)
+
+          subject = described_class.new(person: standin_person)
+
+          expect(subject.to_s).to eq("Hello, Doctor Tester Testerson"), "Look at the Greeting class and replace _placeholder with what this test needs to pass"
+        end
+
+        it "replicates the behavior of your collaborator" do
+          real_person = Person.new
+          real_person.name = "Tester Testerson"
+          real_person.title = "Doctor"
+          subject_with_real_person = described_class.new(person: real_person)
+
+          standin_person = OpenStruct.new(full_name: _placeholder)
+          subject_with_standin_person = described_class.new(person: standin_person)
+
+          expect(subject_with_real_person.to_s).to eq(subject_with_standin_person.to_s), "Update the `full_name` we set in our standin_person with what this test needs to pass"
+        end
+
+        it "requires less setup than using the real collaborator" do
+          real_person = Person.new
+          real_person.name = "Tester Testerson"
+          real_person.title = "Doctor"
+          subject_with_real_person = described_class.new(person: real_person)
+
+          standin_person = OpenStruct.new(full_name: "Doctor Tester Testerson")
+          subject_with_standin_person = described_class.new(person: standin_person)
+
+          # Replace _placeholder with the correct values
+          number_of_lines_configuring_real_person = _placeholder
+          number_of_lines_configuring_standin_person = _placeholder
+
+          # this test shows that our Greeting works the same with a real person and a standin person
+          expect(subject_with_real_person.to_s).to eq(subject_with_standin_person.to_s)
+
+          # Replace __ with the correct operator, >, <, ==, etc
+          expect(number_of_lines_configuring_real_person).to be __(number_of_lines_configuring_standin_person)
+        end
+      end
+
+      describe "and there are downsides to using a plain Ruby collaborator stand in" do
+        it "lets you call methods that don't exist on the real object" do
+          real_person = Person.new
+          standin_person = OpenStruct.new(minnesota: "ope!")
+          #
+          # Replace the _placeholders below to show which person raises an error
+          # And which does not
+          expect { _placeholder.minnesota }.to raise_error(NoMethodError)
+
+          expect { _placeholder.minnesota }.not_to raise_error
+        end
+
+        it "lets you write tests that pass but that fails" do
+          # Imagine someone changes the name of the `full_name`  method in the Person class
+          # But your code in Greeting still calls `person.full_name`
+
+          # This bit of code removes the `full_name` from Person
+          # And replaces it with a new method `new_full_name`
+          class Person
+            undef :full_name
+            def new_full_name
+              "#{name} (#{title})"
+            end
+          end
+
+          real_person = Person.new
+          standin_person = OpenStruct.new(full_name: "Pirate Frederic Penzance")
+
+          # Replace the _placeholders below to show which person raises an error
+          # And which does not
+          expect { described_class.new(person: _placeholder).to_s }.to raise_error(NoMethodError)
+
+          expect { described_class.new(person: _placeholder).to_s }.not_to raise_error
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,8 +20,30 @@ end
 
 class Object
   def _placeholder
-    nil
+    NullObject.new
+  end
+
+  def __(other)
+    false
   end
 end
 
 class PlaceholderError < StandardError; end
+
+# This is the "Black Hole" null object
+# From Avdi Grimm's book "Much Ado Abought Naught"
+# https://github.com/avdi/naught
+class NullObject < BasicObject
+  def method_missing(*)
+    self
+  end
+
+  def respond_to?(*)
+    true
+  end
+  def inspect
+    "<null>"
+  end
+  klass = self
+  define_method(:class) { klass }
+end


### PR DESCRIPTION
This covers testing collaborators using PORO standins (OpenStruct, in
this case).

I wanted a more robust _placeholder so I've replaced it with a black
hole null object

https://github.com/avdi/naught#how-about-a-black-hole-null-object-that-supports-infinite-chaining-of-methods