### PR TITLE
Refactor collaborator config

### DIFF
--- a/lib/config.rb
+++ b/lib/config.rb
@@ -1,0 +1,39 @@
+require 'singleton'
+
+module Config
+  def self.person
+    Person.instance
+  end
+
+  class Person
+    include Singleton
+
+    def slow_down?
+      slow_down == true
+    end
+
+    def slow_down!
+      @slow_down = true
+    end
+
+    def slow_down
+      @slow_down ||= false
+    end
+
+    def new_behavior?
+      new_behavior == true
+    end
+
+    def new_behavior!
+      @new_behavior = true
+    end
+
+    def new_behavior
+      @new_behavior ||= false
+    end
+
+    def default!
+      instance_variables.each { |iv| instance_variable_set(iv, nil) }
+    end
+  end
+end

--- a/lib/person.rb
+++ b/lib/person.rb
@@ -28,10 +28,10 @@ class Person
   attr_accessor :new_behavior, :slow_down
 
   def new_behavior?
-    new_behavior == true
+    ::Config.person.new_behavior?
   end
 
   def slow_down?
-    slow_down == true
+    ::Config.person.slow_down?
   end
 end

--- a/spec/exercises/01_collaborator_class_spec.rb
+++ b/spec/exercises/01_collaborator_class_spec.rb
@@ -1,4 +1,5 @@
 require_relative "../spec_helper"
+require 'config'
 require 'person'
 require 'greeting'
 require 'date'
@@ -26,14 +27,16 @@ RSpec.describe "When testing a collaborator" do
 
       describe "but there are downsides" do
         it "your tests fail when the collaborator changes" do
-          # The new_behavior param changes the internals of the collaborator
-          person = Person.new(new_behavior: true)
+          # This changes the behavior of your person collaborator
+          Config.person.new_behavior!
+
+          person = Person.new
           person.name = "Tester Testerface"
           person.title = "Wizened"
 
           subject = described_class.new(person: person)
 
-          expect(subject.to_s).to eq("Hello, Tester Testerface (Wizened)"), "
+          expect(subject.to_s).to eq("Hello, Wizened Tester Testerface"), "
           Oh no!
           The behavior of Person has changed your test failed.
           You expected 'Hello, Wizened Tester Testerface',
@@ -59,8 +62,10 @@ RSpec.describe "When testing a collaborator" do
         end
 
         it "and your tests are slow if your collaborator is slow" do
-          # The slow_down param slows down your collaborator
-          person = Person.new(slow_down: true)
+          # This slows down your person collaborator
+          Config.person.slow_down!
+
+          person = Person.new
           person.name = "Tester Testerface"
           person.title = "Wizened"
 

--- a/spec/exercises/02_plain_ruby_collaborators_spec.rb
+++ b/spec/exercises/02_plain_ruby_collaborators_spec.rb
@@ -51,10 +51,12 @@ RSpec.describe "When testing a collaborator" do
 
         it "is unaffected by implementation changes in your collaborator" do
           pending
+          fail
         end
 
         it "is unaffected by the speed of your collaborator" do
           pending
+          fail
         end
       end
 

--- a/spec/exercises/02_plain_ruby_collaborators_spec.rb
+++ b/spec/exercises/02_plain_ruby_collaborators_spec.rb
@@ -5,14 +5,14 @@ require 'date'
 require 'ostruct'
 
 RSpec.describe "When testing a collaborator" do
-  describe "you can use plain Ruby objects as a stand-in" do
+  describe "you can use plain Ruby objects as a double" do
     describe Greeting, "using OpenStruct as a collaborator" do
-      describe "there are benefits to using a collaborator stand in" do
+      describe "there are benefits to using a collaborator double" do
         it "it is not hard" do
-          standin_person = OpenStruct.new
-          standin_person.full_name = "Wizened Tester Testerface"
+          double_person = OpenStruct.new
+          double_person.full_name = "Wizened Tester Testerface"
 
-          subject = described_class.new(person: standin_person)
+          subject = described_class.new(person: double_person)
 
           expect(subject.to_s).to eq(_placeholder), "Look at the Greeting class and replace _placeholder with what this test needs to pass"
         end
@@ -23,10 +23,10 @@ RSpec.describe "When testing a collaborator" do
           real_person.title = "Wizened"
           subject_with_real_person = described_class.new(person: real_person)
 
-          standin_person = OpenStruct.new(full_name: _placeholder)
-          subject_with_standin_person = described_class.new(person: standin_person)
+          double_person = OpenStruct.new(full_name: _placeholder)
+          subject_with_double_person = described_class.new(person: double_person)
 
-          expect(subject_with_real_person.to_s).to eq(subject_with_standin_person.to_s), "Update the `full_name` we set in our standin_person with what this test needs to pass"
+          expect(subject_with_real_person.to_s).to eq(subject_with_double_person.to_s), "Update the `full_name` we set in our double_person with what this test needs to pass"
         end
 
         it "requires less setup than using the real collaborator" do
@@ -35,18 +35,18 @@ RSpec.describe "When testing a collaborator" do
           real_person.title = "Wizened"
           subject_with_real_person = described_class.new(person: real_person)
 
-          standin_person = OpenStruct.new(full_name: "Wizened Tester Testerface")
-          subject_with_standin_person = described_class.new(person: standin_person)
+          double_person = OpenStruct.new(full_name: "Wizened Tester Testerface")
+          subject_with_double_person = described_class.new(person: double_person)
 
           # Replace 0 with the correct values
           number_of_lines_configuring_real_person = 0
-          number_of_lines_configuring_standin_person = 0
+          number_of_lines_configuring_double_person = 0
 
-          # this test shows that our Greeting works the same with a real person and a standin person
-          expect(subject_with_real_person.to_s).to eq(subject_with_standin_person.to_s)
+          # this test shows that our Greeting works the same with a real person and a double person
+          expect(subject_with_real_person.to_s).to eq(subject_with_double_person.to_s)
 
           # Replace __ with the correct operator, >, <, ==, etc
-          expect(number_of_lines_configuring_real_person).to be __(number_of_lines_configuring_standin_person)
+          expect(number_of_lines_configuring_real_person).to be __(number_of_lines_configuring_double_person)
         end
 
         it "is unaffected by implementation changes in your collaborator" do
@@ -60,10 +60,10 @@ RSpec.describe "When testing a collaborator" do
         end
       end
 
-      describe "and there are downsides to using a plain Ruby collaborator stand in" do
+      describe "and there are downsides to using a plain Ruby collaborator double" do
         it "lets you call methods that don't exist on the real object" do
           real_person = Person.new
-          standin_person = OpenStruct.new(minnesota: "ope!")
+          double_person = OpenStruct.new(minnesota: "ope!")
           #
           # Replace the _placeholders below to show which person raises an error
           # And which does not
@@ -86,7 +86,7 @@ RSpec.describe "When testing a collaborator" do
           end
 
           real_person = Person.new
-          standin_person = OpenStruct.new(full_name: "Wizened Tester Testerface")
+          double_person = OpenStruct.new(full_name: "Wizened Tester Testerface")
 
           # Replace the _placeholders below to show which person raises an error
           # And which does not

--- a/spec/exercises/02_plain_ruby_collaborators_spec.rb
+++ b/spec/exercises/02_plain_ruby_collaborators_spec.rb
@@ -1,4 +1,5 @@
 require_relative "../spec_helper"
+require 'config'
 require 'person'
 require 'greeting'
 require 'date'
@@ -50,13 +51,49 @@ RSpec.describe "When testing a collaborator" do
         end
 
         it "is unaffected by implementation changes in your collaborator" do
-          pending
-          fail
+          # This changes the behavior of the real person class
+          ::Config.person.new_behavior!
+
+          real_person = Person.new
+          real_person.name = "Tester Testerface"
+          real_person.title = "Wizened"
+          subject_with_real_person = described_class.new(person: real_person)
+
+          double_person = OpenStruct.new
+          double_person.full_name = "Wizened Tester Testerface"
+          subject_with_double_person = described_class.new(person: double_person)
+
+          strings_match = (subject_with_real_person.to_s == subject_with_double_person)
+          expect(strings_match).to be(_placeholder), "
+            Replace the _placeholder with true or false.
+            True if the strings match. False if they don't.
+            Remember what happened when the Person behavior changed in an earlier exercise?"
         end
 
         it "is unaffected by the speed of your collaborator" do
-          pending
-          fail
+          # This slows down the real person class
+          ::Config.person.slow_down!
+
+          start_of_real_person = Time.now
+          real_person = Person.new
+          real_person.name = "Tester Testerface"
+          real_person.title = "Wizened"
+          subject_with_real_person = described_class.new(person: real_person)
+          expect(subject_with_real_person.to_s).to eq "Hello, Wizened Tester Testerface"
+          end_of_real_person = Time.now
+          time_elapsed_testing_real_person = (end_of_real_person - start_of_real_person).to_f
+
+
+          start_of_double_person = Time.now
+          double_person = OpenStruct.new
+          double_person.full_name = "Wizened Tester Testerface"
+          subject_with_double_person = described_class.new(person: double_person)
+          expect(subject_with_double_person.to_s).to eq "Hello, Wizened Tester Testerface"
+          end_of_double_person = Time.now
+          time_elapsed_testing_double_person = (end_of_double_person - start_of_double_person).to_f
+
+          # Replace __ with the correct operator, >, <, ==, etc
+          expect(time_elapsed_testing_double_person).to be __(time_elapsed_testing_real_person)
         end
       end
 
@@ -64,7 +101,7 @@ RSpec.describe "When testing a collaborator" do
         it "lets you call methods that don't exist on the real object" do
           real_person = Person.new
           double_person = OpenStruct.new(minnesota: "ope!")
-          #
+
           # Replace the _placeholders below to show which person raises an error
           # And which does not
           expect { _placeholder.minnesota }.to raise_error(NoMethodError)

--- a/spec/exercises/03_stub_collaborator_spec.rb
+++ b/spec/exercises/03_stub_collaborator_spec.rb
@@ -46,13 +46,46 @@ RSpec.describe "When testing a collaborator" do
       end
 
       it "is unaffected by implementation changes in your collaborator" do
-        pending
-        fail
+        # This changes the behavior of the real person class
+        ::Config.person.new_behavior!
+
+        real_person = Person.new
+        real_person.name = "Tester Testerface"
+        real_person.title = "Wizened"
+        subject_with_real_person = described_class.new(person: real_person)
+
+        double_person = instance_double(Person, full_name: _placeholder)
+        subject_with_double_person = described_class.new(person: double_person)
+
+        strings_match = (subject_with_real_person.to_s == subject_with_double_person)
+        expect(strings_match).to be(_placeholder), "
+            Replace the _placeholder with true or false.
+            True if the strings match. False if they don't.
+            Remember what happened when the Person behavior changed in an earlier exercise?"
       end
 
       it "is unaffected by the speed of your collaborator" do
-        pending
-        fail
+        # This slows down the real person class
+        ::Config.person.slow_down!
+
+        start_of_real_person = Time.now
+        real_person = Person.new
+        real_person.name = "Tester Testerface"
+        real_person.title = "Wizened"
+        subject_with_real_person = described_class.new(person: real_person)
+        expect(subject_with_real_person.to_s).to eq "Hello, Wizened Tester Testerface"
+        end_of_real_person = Time.now
+        time_elapsed_testing_real_person = (end_of_real_person - start_of_real_person).to_f
+
+        start_of_double_person = Time.now
+        double_person = instance_double(Person, full_name: "Wizened Tester Testerface")
+        subject_with_double_person = described_class.new(person: double_person)
+        expect(subject_with_double_person.to_s).to eq "Hello, Wizened Tester Testerface"
+        end_of_double_person = Time.now
+        time_elapsed_testing_double_person = (end_of_double_person - start_of_double_person).to_f
+
+        # Replace __ with the correct operator, >, <, ==, etc
+        expect(time_elapsed_testing_double_person).to be __(time_elapsed_testing_real_person)
       end
 
       it "won't let you call methods that don't exist on the real object" do

--- a/spec/exercises/03_stub_collaborator_spec.rb
+++ b/spec/exercises/03_stub_collaborator_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe "When testing a collaborator" do
   describe Greeting, "you can use a RSpec stub to stand in for the collaborator" do
     describe "there are benefits to using a stub as a stand in" do
       it "it is not hard" do
-        person_double = instance_double(Person, full_name: "Wizened Tester Testerface")
+        double_person = instance_double(Person, full_name: "Wizened Tester Testerface")
 
-        subject = described_class.new(person: person_double)
+        subject = described_class.new(person: double_person)
 
         expect(subject.to_s).to eq(_placeholder), "Look at the Greeting class and replace _placeholder with what this test needs to pass"
       end
@@ -19,10 +19,10 @@ RSpec.describe "When testing a collaborator" do
         real_person.title = "Wizened"
         subject_with_real_person = described_class.new(person: real_person)
 
-        person_double = instance_double(Person, full_name: _placeholder)
-        subject_with_person_double = described_class.new(person: person_double)
+        double_person = instance_double(Person, full_name: _placeholder)
+        subject_with_double_person = described_class.new(person: double_person)
 
-        expect(subject_with_real_person.to_s).to eq(subject_with_person_double.to_s), "Update the `full_name` we set in our standin_person with what this test needs to pass"
+        expect(subject_with_real_person.to_s).to eq(subject_with_double_person.to_s), "Update the `full_name` we set in our standin_person with what this test needs to pass"
       end
 
       it "requires less setup than using the real collaborator" do
@@ -31,18 +31,18 @@ RSpec.describe "When testing a collaborator" do
         real_person.title = "Wizened"
         subject_with_real_person = described_class.new(person: real_person)
 
-        person_double = instance_double(Person, full_name: _placeholder)
-        subject_with_person_double = described_class.new(person: person_double)
+        double_person = instance_double(Person, full_name: _placeholder)
+        subject_with_double_person = described_class.new(person: double_person)
 
         # Replace 0 with the correct values
         number_of_lines_configuring_real_person = 0
-        number_of_lines_configuring_person_double = 0
+        number_of_lines_configuring_double_person = 0
 
         # this test shows that our Greeting works the same with a real person and a standin person
-        expect(subject_with_real_person.to_s).to eq(subject_with_person_double.to_s)
+        expect(subject_with_real_person.to_s).to eq(subject_with_double_person.to_s)
 
         # Replace __ with the correct operator, >, <, ==, etc
-        expect(number_of_lines_configuring_real_person).to be __(number_of_lines_configuring_person_double)
+        expect(number_of_lines_configuring_real_person).to be __(number_of_lines_configuring_double_person)
       end
 
       it "is unaffected by implementation changes in your collaborator" do
@@ -99,12 +99,12 @@ RSpec.describe "When testing a collaborator" do
 
     describe "and there are downsides to using a RSpec stub as a double" do
       it "you are now required to define how it responds to any method you call" do
-        person_double = instance_double(Person, name: "Tester Testerson", title: "Wizened")
+        double_person = instance_double(Person, name: "Tester Testerson", title: "Wizened")
 
-        expect(person_double.name).to eq("Tester Testerson")
-        expect(person_double.title).to eq("Wizened")
+        expect(double_person.name).to eq("Tester Testerson")
+        expect(double_person.title).to eq("Wizened")
 
-        expect { person_double.full_name }.to raise_error(
+        expect { double_person.full_name }.to raise_error(
           an_instance_of(RSpec::Mocks::MockExpectationError)
           .and having_attributes(
             message: a_string_matching(/received unexpected message :full_name/)
@@ -112,12 +112,12 @@ RSpec.describe "When testing a collaborator" do
         )
 
         # Uncomment this line and replace `_placeholder` with
-        # the method you want to call on `person_double`
+        # the method you want to call on `double_person`
         # The methond name can be a symbol (:method_name) or string ('method_name')
-        # allow(person_double).to receive(_placeholder)
+        # allow(double_person).to receive(_placeholder)
 
-        expect { person_double.full_name }.not_to raise_error, "
-        Replace _placeholder with the method you want to call on `person_double`.
+        expect { double_person.full_name }.not_to raise_error, "
+        Replace _placeholder with the method you want to call on `double_person`.
         The method name can be a symbol (:method_name) or string 'method_name')"
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,10 @@ RSpec.configure do |config|
   config.default_formatter = "doc"
 
   config.order = :defined
+
+  config.before(:each) do
+    ::Config.person.default!
+  end
 end
 
 class Object


### PR DESCRIPTION
Refactoring how Person is configured so that I can use a new Config module. This let me fill in the `pending` tests in PORO and the stub collaborator exercises. 